### PR TITLE
Fix leveledit py37

### DIFF
--- a/pgu/tilevid.py
+++ b/pgu/tilevid.py
@@ -171,7 +171,7 @@ class Tilevid(Vid):
         x,y = pos
         tiles = self.tiles
         tw,th = tiles[0].image.get_width(),tiles[0].image.get_height()
-        return x  / tw, y // th
+        return x  // tw, y // th
 
     def tile_to_view(self,pos):
         x,y = pos

--- a/scripts/leveledit
+++ b/scripts/leveledit
@@ -115,9 +115,6 @@ class _app(gui.Container):
         #self.level_w, self.level_h = (self.level.get_width(), self.level.get_height())
         self.level_w, self.level_h = len(self.level.tlayer[0]),len(self.level.tlayer)
 
-        self.tiles_last_ctime = None
-        self.codes_last_ctime = None
-
         self.load_tiles_and_codes()
         
 
@@ -145,15 +142,6 @@ class _app(gui.Container):
 
         self.tiles_fname = cfg['tiles']
         if os.path.isfile(self.tiles_fname):
-            # we check to see if the ctime is the same.
-
-            newctime = os.stat(self.tiles_fname)[9]
-            if newctime <= self.tiles_last_ctime:
-                #nothing to do, so we return.
-                return
-
-            self.tiles_last_ctime = newctime
-
             self.tiles = pygame.image.load(self.tiles_fname)
         else:
             self.tiles = hex_image(self)
@@ -163,12 +151,6 @@ class _app(gui.Container):
 
         self.codes_fname = cfg['codes']
         if os.path.isfile(self.codes_fname):
-            newctime = os.stat(self.codes_fname)[9]
-            if newctime <= self.codes_last_ctime:
-                #nothing to do, so we return.
-                return
-            self.codes_last_ctime = newctime
-
             self.codes = pygame.image.load(self.codes_fname)
         else:
             self.codes = hex_image(self)

--- a/scripts/leveledit
+++ b/scripts/leveledit
@@ -329,8 +329,8 @@ class tpicker(gui.Widget):
         
     def event(self,e):
         if (e.type is MOUSEBUTTONDOWN and e.button == 1) or (e.type is MOUSEMOTION and e.buttons[0] == 1 and self.container.myfocus == self):
-            w = app.tiles_w/app.tile_w
-            x,y = e.pos[0]/app.tile_w,e.pos[1]/app.tile_h
+            w = app.tiles_w//app.tile_w
+            x,y = e.pos[0]//app.tile_w,e.pos[1]//app.tile_h
             n = x+y*w
             self.set(n)
             if app.mode not in ('tile','bkgr'):
@@ -357,8 +357,8 @@ class cpicker(gui.Widget):
         
     def event(self,e):
         if (e.type is MOUSEBUTTONDOWN and e.button == 1) or (e.type is MOUSEMOTION and e.buttons[0] == 1 and self.container.myfocus == self):
-            w = app.codes_w/app.tile_w
-            x,y = e.pos[0]/app.tile_w,e.pos[1]/app.tile_h
+            w = app.codes_w//app.tile_w
+            x,y = e.pos[0]//app.tile_w,e.pos[1]//app.tile_h
             n = x+y*w
             self.set(n)
             app.tools['code'].click()
@@ -433,8 +433,8 @@ class vdraw(gui.Widget):
         s = pygame.Surface((self.rect.w,self.rect.h))
         clrs = [(148,148,148),(108,108,108)]
         inc = 7
-        for y in range(0,self.rect.w/inc):
-            for x in range(0,self.rect.h/inc):
+        for y in range(0,self.rect.w//inc):
+            for x in range(0,self.rect.h//inc):
                 s.fill(clrs[(x+y)%2],(x*inc,y*inc,inc,inc))
         self.bg = s
 

--- a/scripts/leveledit
+++ b/scripts/leveledit
@@ -322,8 +322,8 @@ class tpicker(gui.Widget):
     def paint(self,s):
         s.fill((128,128,128))
         s.blit(app.tiles,(0,0))
-        w = app.tiles_w/app.tile_w
-        x,y = app.tile%w,app.tile/w
+        w = app.tiles_w//app.tile_w
+        x,y = app.tile%w,app.tile//w
         off = x*app.tile_w,y*app.tile_h
         pygame.draw.rect(s,(255,255,255),(off[0],off[1],app.tile_w,app.tile_h),2)
         
@@ -350,8 +350,8 @@ class cpicker(gui.Widget):
     def paint(self,s):
         s.fill((128,128,128))
         s.blit(app.codes,(0,0))
-        w = app.codes_w/app.tile_w
-        x,y = app.code%w,app.code/w
+        w = app.codes_w//app.tile_w
+        x,y = app.code%w,app.code//w
         off = x*app.tile_w,y*app.tile_h
         pygame.draw.rect(s,(255,255,255),(off[0],off[1],app.tile_w,app.tile_h),2)
         
@@ -837,8 +837,8 @@ def cmd_pick(value):
     
     
     if (mods&KMOD_SHIFT) != 0:
-        app.level.view.x += dx*app.vdraw.rect.w/8
-        app.level.view.y += dy*app.vdraw.rect.h/8
+        app.level.view.x += dx*app.vdraw.rect.w//8
+        app.level.view.y += dy*app.vdraw.rect.h//8
         app.vdraw.repaint()
         #x,y = app.view.get_offset()
         #x = x + 1*dx
@@ -860,7 +860,7 @@ def cmd_pick(value):
         
     
     else:
-        w = app.tiles_w/app.tile_w
+        w = app.tiles_w//app.tile_w
         if app.mode == 'code':
             n = app.code + dx + dy*w
             app.cpicker.set(n)


### PR DESCRIPTION
This PR propose changes for multiple crashes in pgu/Scripts/leveledit 

Testbed: win10 64 bits, python 3.3.7 64bits, pygame 1.9.6, pgu from github at commit
commit 8d378586e8cec82d54510dc2d921ee2c5617dd22 (tag: 0.21, origin/master, origin/HEAD, master)
Author: Joao S O Bueno
Date:   Fri Apr 19 02:48:28 2019 -0300

# problem 1
 
Running leveledit
```
	 cd D:\cla\dev2\pgu\examples
	 python ../scripts/leveledit level.tga tiles.tga
```
It crashes with
```
Traceback (most recent call last):
  File "../scripts/leveledit", line 1387, in <module>
    main()
  File "../scripts/leveledit", line 1382, in main
    init_app()
  File "../scripts/leveledit", line 1288, in init_app
    app = _app()
  File "../scripts/leveledit", line 121, in __init__
    self.load_tiles_and_codes()
  File "../scripts/leveledit", line 151, in load_tiles_and_codes
    if newctime <= self.tiles_last_ctime:
TypeError: '<=' not supported between instances of 'int' and 'NoneType'
```
**Analysis**
method _app.load_tiles_and_codes() in pgu/Scripts/leveledit tries to save some time when loading a tileset: it skips the load if the file ctime is <= than the ctime of the currently loaded tileset

Problem is, this fails when no tileset has been loaded, hence  .tiles_last_ctime is None

The minimal fix would be to change
	if newctime <= self.tiles_last_ctime:
to
    if self.tiles_last_ctime is not None and (newctime <= self.tiles_last_ctime):
	
But I think this strategy is wrong: what if you run some tool that changes the file contents and not its ctime? Loading time, even if perceptible, does not matter in an editor (for real cases :))  

So I propose to get ride of this pattern which also repeats when loading the 'codes' part.
The ctimes are only used for those tricks (I searched all the WD for the strings), so the checks are removed and the associated member variables are deleted.

This is the first commit in the PR, 'fix leveledit crash related to ctime'

# problem 2

Trying to run after that patch gives
```
 cd D:\cla\dev2\pgu\examples
 python ../scripts/leveledit level.tga tiles.tga
Traceback (most recent call last):
  File "../scripts/leveledit", line 1369, in <module>
    main()
  File "../scripts/leveledit", line 1364, in main
    init_app()
  File "../scripts/leveledit", line 1313, in init_app
    e = app.vwrap = vwrap()
  File "../scripts/leveledit", line 381, in __init__
    self.vdraw = e = vdraw(width=w-sw,height=h-sw)
  File "../scripts/leveledit", line 436, in __init__
    for y in range(0,self.rect.w/inc):
TypeError: 'float' object cannot be interpreted as an integer
````
**Analysis**
The relevant context is
```
        inc = 7
        for y in range(0,self.rect.w/inc):
            for x in range(0,self.rect.h/inc):
                s.fill(clrs[(x+y)%2],(x*inc,y*inc,inc,inc))
```
It is painting a chessboard of size self.rect, x,y being each tile corner.
So integer division is desired, and it will be
```
        inc = 7
        for y in range(0,self.rect.w//inc):
            for x in range(0,self.rect.h//inc):
                s.fill(clrs[(x+y)%2],(x*inc,y*inc,inc,inc))
```
Whith this the app window shows, but crashes when trying to select the piramid tile in the top-right pane:
```
...
  File "..\pgu\gui\widget.py", line 323, in _event
    return self.event(e)
  File "..\pgu\gui\theme.py", line 354, in theme_event
    return func(sub)
  File "../scripts/leveledit", line 335, in event
    self.set(n)
  File "../scripts/leveledit", line 340, in set
    if n < 0 or n >= len(app.level.tiles) or app.level.tiles[n] == None: return
TypeError: list indices must be integers or slices, not float
```
**Analysis**
The code involved is
```
    def event(self,e):
        if (e.type is MOUSEBUTTONDOWN and e.button == 1) or (e.type is MOUSEMOTION and e.buttons[0] == 1 and self.container.myfocus == self):
            w = app.tiles_w/app.tile_w
            x,y = e.pos[0]/app.tile_w,e.pos[1]/app.tile_h
            n = x+y*w
            self.set(n)
            ...
	def set(self,n):
        if n < 0 or n >= len(app.level.tiles) or app.level.tiles[n] == None: return
        app.tile = n
```
The tiles in the tileset are stored in the list app.level.tiles, the code in event wants to go from screen coords to list index, and it is clear that integer division is the correct way

The same happens clicking on a tile in the bottom-right panel, with same analysis and fix.

Both fixes in the second commit, "fix leveledit crash when click on right panels"

# Problem 3
 
After the second patch, clicking on the Left crashes the app:
```
...
  File "../scripts/leveledit", line 512, in event
    if hasattr(self,a): getattr(self,a)(e)
  File "../scripts/leveledit", line 555, in tile_down
    self.tile_drag(e)
  File "../scripts/leveledit", line 566, in tile_drag
    app.level.tlayer[ty][tx] = app.tile
TypeError: list indices must be integers or slices, not float
```
The inmediate code context is:
```
    def tile_drag(self,e):
        pos = self.getpos(e)
        #r,g,b,a = app.view.get_at(pos)
        #r = app.tile
        #app.view.set_at(pos,(r,g,b))
        
        if pos == None: return
        tx,ty = pos
        app.mod(pygame.Rect(tx,ty,1,1))
        app.level.tlayer[ty][tx] = app.tile
        self.repaint()
```
It can be 'fixed' by intifyng tx, ty; but similar problems will pop.
Maybe self.getpos(e) should return int, int ?
Bactracking show this fragment in tilevid.py:
```
    def view_to_tile(self,pos):
        x,y = pos
        tiles = self.tiles
        tw,th = tiles[0].image.get_width(),tiles[0].image.get_height()
        return x  / tw, y // th
```
Here it is clear that x is missing an integer division

Changed this, test crash avoided, this is the 3rd commit, "fix leveledit crash when click in left panel"

(aside: in methods getpos and getpos2 , class vdraw in leveledit theres dead code after a return, I left that to not complicate the diff. This could be cleared at a later time if desired)

# Problem 4
Start as alwayys, press Left Right Arrow key, crash:
```
...
  File "..\pgu\gui\theme.py", line 354, in theme_event
    return func(sub)
  File "../scripts/leveledit", line 289, in event
    cmd(value)
  File "../scripts/leveledit", line 869, in cmd_pick
    app.tpicker.set(n)
  File "../scripts/leveledit", line 340, in set
    if n < 0 or n >= len(app.level.tiles) or app.level.tiles[n] == None: return
TypeError: list indices must be integers or slices, not float
```
**Analysis**

The binding is defined at L 963,
```
keys = [
    ...
    (K_RIGHT,cmd_pick,(1,0)),
```
cmd_pick (around line 833) was called with value =(1, 0)
and no shift or ctrl was pressed, so the code flows to the else, where it tries to advance one tile in the direction received as value. Needs int division.

With the int division the app does not crash when arrow, but going to right the selection box wrongly goes down one pixel each keypress. 

Following the code, both cpicker.paint and tpicker.paint needs int division, and running with this change shows correct displacement with arrows in both right panels.

While looking at cmd_pick, the flow when an arrow is pressed with the shift key wants to slide the view by 1/8 of the view dimension in the relevant direction, and that calls for integer division to not set the level view origin to float value. Corrected.

This is the 4-th commit, "fix leveleditor crash when pressing arrows keys"

They are still other sections that need to use integer division and some other problems but i will stop here to not make a too big PR
