### PR TITLE
fix crashes in tab and arrows navigation

### DIFF
--- a/pgu/gui/container.py
+++ b/pgu/gui/container.py
@@ -235,7 +235,7 @@ class Container(widget.Widget):
         if not used and e.type is KEYDOWN:
             if e.key is K_TAB and self.myfocus:
                 if not (e.mod & KMOD_SHIFT):
-                    next(self.myfocus)
+                    self.myfocus.next()
                 else:
                     self.myfocus.previous()
                     return True
@@ -281,7 +281,7 @@ class Container(widget.Widget):
             if dy_ < 0 and wrect.bottom > rect.top: continue
             dist.append((dx*dx+dy*dy,w))
         if not len(dist): return
-        dist.sort()
+        dist.sort(key=lambda e: e[0])
         d,w = dist.pop(0)
         w.focus()
 
@@ -339,6 +339,7 @@ class Container(widget.Widget):
         if self.myfocus: self.blur(self.myfocus)
         if self.myhover is not w: self.enter(w)
         self.myfocus = w
+        print("C focus:", w.dname)
         w._event(pygame.event.Event(FOCUS))
 
         #print self.myfocus,self.myfocus.__class__.__name__


### PR DESCRIPTION
Fix crashes when running under python 3.x, tested with 3.7 and doing TAB or Arrows navigation.
Problematic code was in pgu.gui.container

**Problem 1**
Crash when navigating with arrow keys, by example running pgu/examples/gui5.py, clicking on the button 'click me' and pressing key down arrow:
```
Traceback (most recent call last):
  File "gui5.py", line 98, in <module>
    app.run(c)
  File "..\pgu\gui\app.py", line 246, in run
    self.loop()
  File "..\pgu\gui\app.py", line 186, in loop
    self.event(e)
  File "..\pgu\gui\app.py", line 169, in event
    container.Container.event(self, ev)
  File "..\pgu\gui\container.py", line 233, in event
    used = w._event(sub)
  File "..\pgu\gui\widget.py", line 323, in _event
    return self.event(e)
  File "..\pgu\gui\theme.py", line 354, in theme_event
    return func(sub)
  File "..\pgu\gui\container.py", line 233, in event
    used = w._event(sub)
  File "..\pgu\gui\widget.py", line 323, in _event
    return self.event(e)
  File "..\pgu\gui\theme.py", line 354, in theme_event
    return func(sub)
  File "..\pgu\gui\container.py", line 249, in event
    self._move_focus(0,1)
  File "..\pgu\gui\container.py", line 284, in _move_focus
    dist.sort()
TypeError: '<' not supported between instances of 'Checkbox' and 'Checkbox'
```
Trivial fix by
```
-        dist.sort()
+        dist.sort(key=lambda e: e[0])
```

** Problem 2 **
Crash when navigating with TAB, by example running pgu(examples/gui1.py and pressing key TAB
```
Traceback (most recent call last):
  File "gui1.py", line 22, in <module>
    app.run(e)
  File "..\pgu\gui\app.py", line 246, in run
    self.loop()
  File "..\pgu\gui\app.py", line 186, in loop
    self.event(e)
  File "..\pgu\gui\app.py", line 169, in event
    container.Container.event(self, ev)
  File "..\pgu\gui\container.py", line 238, in event
    next(self.myfocus)
```

Fixed by
```
-                    next(self.myfocus)
+                    self.myfocus.next()
```
Explanation: 
The original code for pgu.gui.container was developed before python 2.6, and used methods .previous(self, widget=None) and .next(self, widget=None). At this time next was not a special python method

In python 2.6 .next becomes a special method used for iterators; from python 2.7 docs:
>next(iterator[, default])
Retrieve the next item from the iterator by calling its next() method. If default is given, it is returned if the iterator is exhausted, otherwise StopIteration is raised.
New in version 2.6.

So at some point in time the code in container changed to use the function next() to call container.next()

But in python 3,x the special iterator method changed to `__next__`

Reverting to the initial explicit style fixed the problem
