### PR TITLE
Data themes: fix crashes, py3 compliant

### DIFF
--- a/data/themes/clean/notes.txt
+++ b/data/themes/clean/notes.txt
@@ -1,0 +1,19 @@
+- This is a full style, that is it covers all stock widgets.
+
+- All the files referenced in style.ini are present.
+
+- They are some image files not referenced in the style.ini, 
+    box.down.png
+    box.normal.png
+    console.input.focus.png
+    console.input.normal.png
+    console.png
+    menu.option.normal.png
+
+- Comparing the style.ini with the one from 'default', they are some
+  missing keys and some new keys. Missing keys, be it intentional or not,
+  make this style not react to blur (hover)
+
+- Being based on gray colors, and with not blur, an user may have
+  problem to distinguish between a disabled widget and a normal widget.
+

--- a/data/themes/clean/style.ini
+++ b/data/themes/clean/style.ini
@@ -238,7 +238,6 @@ padding_left = 6
 padding_right = 6
 padding_top = 3
 padding_bottom = 3
-arrow = select.arrow.png
 
 [menu.label]
 font = Vera.ttf 16

--- a/data/themes/clean/style.ini
+++ b/data/themes/clean/style.ini
@@ -133,9 +133,6 @@ bar = slider.bar.normal.png
 width = 20
 height = 20
 
-[vslider:down]
-bar = slider.bar.normal.png
-
 [vslider]
 background = slider.png
 bar = slider.bar.normal.png
@@ -168,13 +165,11 @@ padding_right = 4
 padding_top = 1
 padding_bottom = 1
 
-[select.option]
-background = select.option.normal.png
-
 [select.option:hover]
 background = select.option.hover.png
 
 [select.option]
+background = select.option.normal.png
 padding_left = 1
 padding_right = 1
 padding_top = 1
@@ -243,6 +238,7 @@ padding_left = 6
 padding_right = 6
 padding_top = 3
 padding_bottom = 3
+arrow = select.arrow.png
 
 [menu.label]
 font = Vera.ttf 16
@@ -266,15 +262,13 @@ background = menu.down.png
 
 [menu.options]
 background = select.options.png
-background = menu.option.normal.png
-padding_left = 6
-padding_right = 6
+#background = menu.option.normal.png
+#padding_left = 6
+#padding_right = 6
 padding_top = 1
 padding_bottom = 1
 padding_left = 1
 padding_right = 1
-padding_top = 1
-padding_bottom = 1
 
 [menu.option:hover]
 background = menu.option.hover.png
@@ -282,9 +276,6 @@ background = menu.option.hover.png
 [menu.option.label]
 font = Vera.ttf 16
 color = #000000
-
-[menu]
-arrow = select.arrow.png
 
 [scrollarea.content]
 background = #ffffff

--- a/data/themes/default/notes.txt
+++ b/data/themes/default/notes.txt
@@ -1,8 +1,17 @@
-dot and box.xcf:
+- This is a full style, that is, it covers all stock widgets.
+- All the files referenced in style.ini are present.
+- This theme was built by first drawing a set of base images, then
+  running generate.py to produce some more images.
+- They are some files not directly referenced in the style.ini, 
+  still kept here for the benefit of generate.py
+
+---
+
+dot and box.xcf: probably used by the artist as base to generate the
+basic image elements. 
 
 color -170
 
 .down
 .hover +64 brightness
 .normal, grayscale +127 brightness, +48 contrast
-

--- a/data/themes/default/style.ini
+++ b/data/themes/default/style.ini
@@ -223,7 +223,6 @@ background = list.item.down.png
 background = list.item.down.png
 
 [menu]
-arrow = select.arrow.tga
 background = menu.normal.tga
 padding_bottom = 3
 padding_left = 6

--- a/data/themes/gray/notes.txt
+++ b/data/themes/gray/notes.txt
@@ -1,0 +1,14 @@
+- This is a full style, that is it covers all stock widgets.
+- All the files referenced in style.ini are present.
+- They are some image files not referenced in the style.ini, 
+    box.down.png
+    box.normal.png
+    console.input.focus.png
+    console.input.normal.png
+    console.png
+- All the keys in this theme style.ini are also in the default theme,
+  but there's a number of keys in default not present here.
+  As a consequence, no blur (hover) effect is rendered, nor 'down' (clicked)
+  Unsure if this is a design decision or a work unfinished.
+- Being based on gray colors, and with not blur, an user may have
+  problem to distinguish between a disabled widget and a normal widget.

--- a/data/themes/gray/style.ini
+++ b/data/themes/gray/style.ini
@@ -27,8 +27,10 @@ font = mono 16
 [desktop]
 background = desktop.png
 
-[dialog.bar]
+[dialog]
 background = dialog.bar.png
+
+[dialog.bar]
 padding_bottom = 1
 padding_left = 8
 padding_right = 8
@@ -107,11 +109,14 @@ color = #000000
 font = Vera.ttf 10
 
 [hscrollbar]
-background = slider.png
-bar = slider.bar.normal.png
-height = 15
 minus = hslider.left.png
 plus = hslider.right.png
+
+[hscrollbar.slider]
+background = slider.png
+bar = slider.bar.normal.png
+height = 16
+width = 16
 
 [hslider]
 background = slider.png
@@ -331,11 +336,14 @@ color = #000000
 font = Vera.ttf 16
 
 [vscrollbar]
-background = slider.png
-bar = slider.bar.normal.png
 minus = vslider.up.png
 plus = vslider.down.png
-width = 15
+
+[vscrollbar.slider]
+background = slider.png
+bar = slider.bar.normal.png
+height = 16
+width = 16
 
 [vslider]
 background = slider.png

--- a/data/themes/gray/style.ini
+++ b/data/themes/gray/style.ini
@@ -188,7 +188,6 @@ color = #000000
 font = Vera.ttf 14
 
 [menu]
-arrow = select.arrow.png
 background = menu.normal.png
 padding_bottom = 3
 padding_left = 6

--- a/data/themes/tools/convertconfig.py
+++ b/data/themes/tools/convertconfig.py
@@ -6,15 +6,15 @@ import sys
 try:
     path = sys.argv[1]
 except:
-    print "usage: convertconfig.py config.txt"
-    print ""
-    print "Converts the old PGU theme config.txt format into the style.ini format"
-    print ""
+    print("usage: convertconfig.py config.txt")
+    print("")
+    print("Converts the old PGU theme config.txt format into the style.ini format")
+    print("")
     sys.exit(1)
 
 styleByClass = collections.defaultdict(dict)
 
-fd = file(path, "r")
+fd = open(path, "r")
 for line in fd.readlines():
     line = line.strip()
     if (not line): continue
@@ -25,14 +25,14 @@ for line in fd.readlines():
         attr = args[1]
         values = " ".join(args[2:])
     except:
-        print "Invalid line: %s" % line
+        print("Invalid line: %s" % line)
         sys.exit()
     styleByClass[name][attr] = values
 fd.close()
 
 for klass in sorted(styleByClass.keys()):
-    print "[%s]" % klass
+    print("[%s]" % klass)
     for attr in sorted(styleByClass[klass].keys()):
-        print "%s = %s" % (attr, styleByClass[klass][attr])
-    print ""
+        print("%s = %s" % (attr, styleByClass[klass][attr]))
+    print("")
 

--- a/data/themes/tools/notes.txt
+++ b/data/themes/tools/notes.txt
@@ -1,0 +1,3 @@
+- this is a partial theme which provides some icons
+  for the toolbar used in leveledit
+  


### PR DESCRIPTION
Work is done entirelly in the data/themes directory

## Problem 1
script data/themes/tools/convertconfig.py does not run in py3 (print, also file instead of open)
easily fixed, that is commit 1

## Problem 2
When trying to use the theme clean in the examples, app crashes at loading the theme with tracebacks like
```
File "C:\Python37\lib\configparser.py", line 1065, in _readlineno)
configparser.DuplicateSectionError: While reading from \\dev\\pgu\\data\\themes\\clean\\style.ini' [line 145]: 
section 'vslider:down' already exists
```
or
```
configparser.DuplicateOptionError: While reading from 'D:\\dev\\pgu\\data\\theme
s\\clean\\style.ini' [line 264]: option 'background' in section 'menu.options' a
lready exists
```
Duplication in sections and keys was confirmed in data/themes/clean/style.ini , and traced to the commit that did the conversion from config.txt to style.ini ( commit 51d8be4346f , Mar 16 03:19:51 2012 +0000)

Some duplications were easy to resolve, the ones on  [menu.options] were more ambigous. By comparing with theme default and the settings pre-conversion I commented out a set of duplicates; testing with gui5, gui9, the visuals appeared reasonable and no crash seen.

This was the second commit

## Problem 3

When running gui6.py with theme gray, pressing on the button crashes the app and gives a traceback:
```
...
  File "d:\dev\pgu\pgu\gui\slider.py", line 21, in __init__
    self.style.check("bar")
  File "d:\dev\pgu\pgu\gui\style.py", line 26, in check
    raise StyleError("Cannot find the style attribute '%s' for '%s'" % (attr, de
sc))
pgu.gui.errors.StyleError: Cannot find the style attribute 'bar' for 'vscrollbar
.slider'
```
Comparing the style.ini in themes default with the one in theme gray shows some entries missing from gray.
Adding the few missing entries fixed the problem

This was the 3rd commit.

## Problem 4
There's only one resource mentioned in theme default that is not present in the 'default' dir:
```
[menu]
arrow = select.arrow.tga
```
In theme 'clean' theres the same key, with value  menu.normal.tga and the resource is present in the 'clean'  directory.
A search in the pgu *menu* code shows no hit for style.arrow, and scripts using menus work normal after deleting the arrow key on menu section, so deleted.
Deleted same key in 'clear' for same reasons
Similar for the 'gray' theme

This was the 4th commit

## Commit 5
Edited / Added a notes.txt to each theme to make visible some things learned while visiting themes
