### PR TITLE
pygame2 b10 compatibilty

### DIFF
--- a/examples/gui9.py
+++ b/examples/gui9.py
@@ -149,7 +149,7 @@ class Painter(gui.Widget):
             if hasattr(self,app.mode.value+"_motion"):
                 action = getattr(self,app.mode.value+"_motion")
                 action(e)
-        if e.type is gui.MOUSEBUTTONUP:
+        if e.type == gui.MOUSEBUTTONUP:
             if hasattr(self,app.mode.value+"_up"):
                 action = getattr(self,app.mode.value+"_up")
                 action(e)

--- a/pgu/gui/app.py
+++ b/pgu/gui/app.py
@@ -175,6 +175,8 @@ class App(container.Container):
                     'pos' : ev.pos})
                 self.send(sub.type,sub)
                 container.Container.event(self,sub)
+        if ev.type == VIDEOEXPOSE:
+            self.chsize()
     
     def loop(self):
         """Performs one iteration of the PGU application loop, which


### PR DESCRIPTION
Testing done with pygame2 beta 10,  win7, py 3.8
After fixing the pgu code, also tested with pygame 1.9.6, works normal.

## Problem 1

When the pygame window is covered and uncovered, it remains dirty. Sometimes a mouse click or key press triggers a redraw that cleans the window, in some examples that does not happen.

Fixed by listening to  VIDEOEXPOSE in App.event and then triggering a redraw by calling App.chsize()
This is the first commit.

## Problem 2

In example gui9.py , when in mode 'draw', it is supposed to draw only when Lmousebutton is down, but it does not stop drawing when the mouse button is released. Other modes have similar problem in that the MOUSEBUTTONUP seems to not be detected.

Fixed by changing `MOUSEBUTTONUP is ...` to  `MOUSEBUTTONUP == ...` in gui9.py, this is the second commit
