### PR TITLE
pygame2 b10 fix unresponsiveness to some events

### DIFF
--- a/examples/engine1.py
+++ b/examples/engine1.py
@@ -17,14 +17,14 @@ class Red(engine.State):
         s.fill((255,0,0))
         pygame.display.flip()
     def event(self,e): 
-        if e.type is KEYDOWN: return Green(self.game)
+        if e.type == KEYDOWN: return Green(self.game)
         
 class Green(engine.State):
     def paint(self,s): 
         s.fill((0,255,0))
         pygame.display.flip()
     def event(self,e): 
-        if e.type is KEYDOWN: return Blue(self.game)
+        if e.type == KEYDOWN: return Blue(self.game)
 
 ##A state may subclass engine.State.
 ##::
@@ -51,7 +51,7 @@ class Blue(engine.State):
     ##returns a value, it will become the new state.
     ##::
     def event(self,e): 
-        if e.type is KEYDOWN: return Red(self.game)
+        if e.type == KEYDOWN: return Red(self.game)
     ##
     ##Loop is called once a frame.  It should contain all the
     ##logic.  If the loop method returns a value it will become the

--- a/examples/gui10.py
+++ b/examples/gui10.py
@@ -169,9 +169,9 @@ clock = pygame.time.Clock()
 done = False
 while not done:
     for e in pygame.event.get():
-        if e.type is QUIT: 
+        if e.type == QUIT: 
             done = True
-        elif e.type is KEYDOWN and e.key == K_ESCAPE: 
+        elif e.type == KEYDOWN and e.key == K_ESCAPE: 
             done = True
         else:
             app.event(e)

--- a/examples/hexvid1.py
+++ b/examples/hexvid1.py
@@ -52,8 +52,8 @@ def run(g):
     
     while not g.quit:
         for e in pygame.event.get():
-            if e.type is QUIT: g.quit = 1
-            if e.type is KEYDOWN and e.key == K_ESCAPE: g.quit = 1
+            if e.type == QUIT: g.quit = 1
+            if e.type == KEYDOWN and e.key == K_ESCAPE: g.quit = 1
         
         g.loop()
         updates = g.update(g.screen)

--- a/examples/html1.py
+++ b/examples/html1.py
@@ -33,5 +33,5 @@ pygame.display.flip()
 _quit = 0
 while not _quit:
     for e in pygame.event.get():
-        if e.type is QUIT: _quit = 1
+        if e.type == QUIT: _quit = 1
     pygame.time.wait(10)

--- a/examples/isovid1.py
+++ b/examples/isovid1.py
@@ -52,8 +52,8 @@ def run(g):
     
     while not g.quit:
         for e in pygame.event.get():
-            if e.type is QUIT: g.quit = 1
-            if e.type is KEYDOWN and e.key == K_ESCAPE: g.quit = 1
+            if e.type == QUIT: g.quit = 1
+            if e.type == KEYDOWN and e.key == K_ESCAPE: g.quit = 1
         
         g.loop()
         updates = g.update(g.screen)

--- a/examples/layout1.py
+++ b/examples/layout1.py
@@ -59,5 +59,5 @@ pygame.display.flip()
 _quit = 0
 while not _quit:
     for e in pygame.event.get():
-        if e.type is QUIT: _quit = 1
+        if e.type == QUIT: _quit = 1
     pygame.time.wait(10)

--- a/examples/text1.py
+++ b/examples/text1.py
@@ -33,5 +33,5 @@ pygame.display.flip()
 _quit = 0
 while not _quit:
     for e in pygame.event.get():
-        if e.type is QUIT: _quit = 1
+        if e.type == QUIT: _quit = 1
     pygame.time.wait(10)

--- a/examples/tilevid1.py
+++ b/examples/tilevid1.py
@@ -76,8 +76,8 @@ def run(g):
     
     while not g.quit:
         for e in pygame.event.get():
-            if e.type is QUIT: g.quit = 1
-            if e.type is KEYDOWN and e.key == K_ESCAPE: g.quit = 1
+            if e.type == QUIT: g.quit = 1
+            if e.type == KEYDOWN and e.key == K_ESCAPE: g.quit = 1
         
         g.loop()
         updates = g.update(g.screen)

--- a/examples/tilevid2.py
+++ b/examples/tilevid2.py
@@ -47,8 +47,8 @@ def run(g):
     
     while not g.quit:
         for e in pygame.event.get():
-            if e.type is QUIT: g.quit = 1
-            if e.type is KEYDOWN and e.key == K_ESCAPE: g.quit = 1
+            if e.type == QUIT: g.quit = 1
+            if e.type == KEYDOWN and e.key == K_ESCAPE: g.quit = 1
             
         ##In run(), each frame I move the view to the right by SPEED pixels.
         ##::

--- a/examples/tilevid3.py
+++ b/examples/tilevid3.py
@@ -99,8 +99,8 @@ def run(g):
     
     while not g.quit:
         for e in pygame.event.get():
-            if e.type is QUIT: g.quit = 1
-            if e.type is KEYDOWN and e.key == K_ESCAPE: g.quit = 1
+            if e.type == QUIT: g.quit = 1
+            if e.type == KEYDOWN and e.key == K_ESCAPE: g.quit = 1
             
         g.view.x += SPEED
 

--- a/examples/tilevid4.py
+++ b/examples/tilevid4.py
@@ -128,8 +128,8 @@ def run(g):
     
     while not g.quit:
         for e in pygame.event.get():
-            if e.type is QUIT: g.quit = 1
-            if e.type is KEYDOWN and e.key == K_ESCAPE: g.quit = 1
+            if e.type == QUIT: g.quit = 1
+            if e.type == KEYDOWN and e.key == K_ESCAPE: g.quit = 1
             
         g.view.x += SPEED
         g.run_codes(cdata,(g.view.right//TW,0,1,17))

--- a/examples/tilevid5.py
+++ b/examples/tilevid5.py
@@ -208,15 +208,15 @@ def run(g):
     
     while not g.quit:
         for e in pygame.event.get():
-            if e.type is QUIT: g.quit = 1
-            if e.type is KEYDOWN and e.key == K_ESCAPE: g.quit = 1
+            if e.type == QUIT: g.quit = 1
+            if e.type == KEYDOWN and e.key == K_ESCAPE: g.quit = 1
             ##In run(), in the event loop, checking for F10 for full screen, RETURN for pause.
             ##::
-            if e.type is KEYDOWN and e.key == K_F10:
+            if e.type == KEYDOWN and e.key == K_F10:
                 #g.screen = pygame.display.set_mode((SW,SH),FULLSCREEN|HWSURFACE|DOUBLEBUF)
                 pygame.display.toggle_fullscreen()
                 
-            if e.type is KEYDOWN and e.key == K_RETURN:
+            if e.type == KEYDOWN and e.key == K_RETURN:
                 g.pause ^= 1
             ##
 

--- a/pgu/engine.py
+++ b/pgu/engine.py
@@ -125,7 +125,7 @@ class Game:
         state
 
         """
-        if e.type is QUIT: 
+        if e.type == QUIT: 
             self.state = Quit(self)
             return 1
 

--- a/pgu/gui/container.py
+++ b/pgu/gui/container.py
@@ -232,7 +232,7 @@ class Container(widget.Widget):
             if (sub):
                 used = w._event(sub)
 
-        if not used and e.type is KEYDOWN:
+        if not used and e.type == KEYDOWN:
             if e.key is K_TAB and self.myfocus:
                 if not (e.mod & KMOD_SHIFT):
                     self.myfocus.next()

--- a/pgu/gui/slider.py
+++ b/pgu/gui/slider.py
@@ -65,7 +65,7 @@ class _slider(widget.Widget):
                 else:
                     x,y,adj = e.pos[0],e.pos[1],1
                     
-        elif e.type is KEYDOWN:
+        elif e.type == KEYDOWN:
             if self.orient == _SLIDER_HORIZONTAL and e.key == K_LEFT:
                 self.value -= self.step
                 used = True

--- a/scripts/leveledit
+++ b/scripts/leveledit
@@ -283,7 +283,7 @@ class _app(gui.Container):
         
             
     def event(self,e):
-        if e.type is KEYDOWN:
+        if e.type == KEYDOWN:
             for key,cmd,value in keys:
                 if e.key == key:
                     cmd(value)
@@ -328,7 +328,7 @@ class tpicker(gui.Widget):
         pygame.draw.rect(s,(255,255,255),(off[0],off[1],app.tile_w,app.tile_h),2)
         
     def event(self,e):
-        if (e.type is MOUSEBUTTONDOWN and e.button == 1) or (e.type is MOUSEMOTION and e.buttons[0] == 1 and self.container.myfocus == self):
+        if (e.type == MOUSEBUTTONDOWN and e.button == 1) or (e.type == MOUSEMOTION and e.buttons[0] == 1 and self.container.myfocus == self):
             w = app.tiles_w//app.tile_w
             x,y = e.pos[0]//app.tile_w,e.pos[1]//app.tile_h
             n = x+y*w
@@ -356,7 +356,7 @@ class cpicker(gui.Widget):
         pygame.draw.rect(s,(255,255,255),(off[0],off[1],app.tile_w,app.tile_h),2)
         
     def event(self,e):
-        if (e.type is MOUSEBUTTONDOWN and e.button == 1) or (e.type is MOUSEMOTION and e.buttons[0] == 1 and self.container.myfocus == self):
+        if (e.type == MOUSEBUTTONDOWN and e.button == 1) or (e.type == MOUSEMOTION and e.buttons[0] == 1 and self.container.myfocus == self):
             w = app.codes_w//app.tile_w
             x,y = e.pos[0]//app.tile_w,e.pos[1]//app.tile_h
             n = x+y*w
@@ -502,23 +502,23 @@ class vdraw(gui.Widget):
         #pygame.draw.rect(s,(255,255,255,128),Rect(r.x*self.rect.w//app.view_w,r.y*self.rect.h//app.view_h,r.w*self.rect.w//app.view_w,r.h*self.rect.h//app.view_h),4)
         
     def event(self,e):
-        if e.type is MOUSEMOTION:
+        if e.type == MOUSEMOTION:
             self.getpos(e)
-        if (e.type is MOUSEBUTTONDOWN and e.button == 3) or (e.type is MOUSEMOTION and e.buttons[2]==1 and self.container.myfocus == self):
+        if (e.type == MOUSEBUTTONDOWN and e.button == 3) or (e.type == MOUSEMOTION and e.buttons[2]==1 and self.container.myfocus == self):
             self.picker_down(e)
-        if e.type is MOUSEBUTTONDOWN and e.button == 1:
+        if e.type == MOUSEBUTTONDOWN and e.button == 1:
             self.getpos(e)
             a = '%s_down'%app.mode
             if hasattr(self,a): getattr(self,a)(e)
-        if e.type is MOUSEMOTION and e.buttons[0] and self.container.myfocus == self:
+        if e.type == MOUSEMOTION and e.buttons[0] and self.container.myfocus == self:
             a = '%s_drag'%app.mode
             if hasattr(self,a): getattr(self,a)(e)
-        if e.type is MOUSEBUTTONUP and e.button == 1:
+        if e.type == MOUSEBUTTONUP and e.button == 1:
             a = '%s_up'%app.mode
             if hasattr(self,a): getattr(self,a)(e)
-        if e.type is MOUSEBUTTONDOWN and e.button == 2:
+        if e.type == MOUSEBUTTONDOWN and e.button == 2:
             self.move_down(e)
-        if e.type is MOUSEMOTION and e.buttons[1] and self.container.myfocus == self:
+        if e.type == MOUSEMOTION and e.buttons[1] and self.container.myfocus == self:
             self.move_drag(e)
     
     #move

--- a/scripts/tileedit
+++ b/scripts/tileedit
@@ -162,7 +162,7 @@ class _app(gui.Container):
             if hasattr(self,'tpicker'): self.tpicker.repaint()
             if hasattr(self,'tpreview'): self.tpreview.repaint()
     def event(self,e):
-        if e.type is KEYDOWN:
+        if e.type == KEYDOWN:
             for key,cmd,value in keys:
                 if e.key == key:
                     cmd(value)
@@ -193,7 +193,7 @@ class cpicker(gui.Widget):
         s.blit(pygame.transform.scale(self.palette,(self.rect.w,self.rect.h)),(0,0))
             
     def event(self,e):
-        if (e.type is MOUSEBUTTONDOWN) or (e.type is MOUSEMOTION and e.buttons[0] == 1 and self.container.myfocus == self):
+        if (e.type == MOUSEBUTTONDOWN) or (e.type == MOUSEMOTION and e.buttons[0] == 1 and self.container.myfocus == self):
             x,y = e.pos[0]*self.palette_w//self.rect.w,e.pos[1]*self.palette_h//self.rect.h
             x,y = max(0,x),max(0,y)
             x,y = min(self.palette_w-1,x),min(self.palette_h-1,y)
@@ -221,11 +221,11 @@ class tpicker(gui.Widget):
         app.tile = app.tiles.subsurface((x,y,app.tile_w,app.tile_h))
 
     def event(self,e):
-        if (e.type is MOUSEBUTTONDOWN and e.button == 1) or (e.type is MOUSEMOTION and e.buttons[0] == 1 and self.container.myfocus == self):
+        if (e.type == MOUSEBUTTONDOWN and e.button == 1) or (e.type == MOUSEMOTION and e.buttons[0] == 1 and self.container.myfocus == self):
             x,y = e.pos[0]//app.tile_w*app.tile_w,e.pos[1]//app.tile_h*app.tile_h
             self.pick((x,y))
             
-        if (e.type is MOUSEBUTTONDOWN and e.button == 3) or (e.type is MOUSEMOTION and e.buttons[2] == 1 and self.container.myfocus == self):
+        if (e.type == MOUSEBUTTONDOWN and e.button == 3) or (e.type == MOUSEMOTION and e.buttons[2] == 1 and self.container.myfocus == self):
             x,y = e.pos[0]-app.tile_w//2,e.pos[1]-app.tile_h//2
             x = min(self.rect.w-app.tile_w-1,max(0,x))
             y = min(self.rect.h-app.tile_h-1,max(0,y))
@@ -287,15 +287,15 @@ class tdraw(gui.Widget):
         pygame.draw.rect(s,(255,255,255,128),Rect(r.x*self.rect.w//app.tile_w,r.y*self.rect.h//app.tile_h,r.w*self.rect.w//app.tile_w,r.h*self.rect.h//app.tile_h),4)
         
     def event(self,e):
-        if (e.type is MOUSEBUTTONDOWN and e.button == 3) or (e.type is MOUSEMOTION and e.buttons[2]==1 and self.container.myfocus == self):
+        if (e.type == MOUSEBUTTONDOWN and e.button == 3) or (e.type == MOUSEMOTION and e.buttons[2]==1 and self.container.myfocus == self):
             self.picker_down(e)
-        if e.type is MOUSEBUTTONDOWN and e.button == 1:
+        if e.type == MOUSEBUTTONDOWN and e.button == 1:
             a = '%s_down'%app.mode
             if hasattr(self,a): getattr(self,a)(e)
-        if e.type is MOUSEMOTION and e.buttons[0] and self.container.myfocus == self:
+        if e.type == MOUSEMOTION and e.buttons[0] and self.container.myfocus == self:
             a = '%s_drag'%app.mode
             if hasattr(self,a): getattr(self,a)(e)
-        if e.type is MOUSEBUTTONUP and e.button == 1:
+        if e.type == MOUSEBUTTONUP and e.button == 1:
             a = '%s_up'%app.mode
             if hasattr(self,a): getattr(self,a)(e)
             


### PR DESCRIPTION
Test with pygame2 b10, win7, py3.8

## Problem 1
pgu/Scripts/leveledit unresponsive to mouse events

Looks similar to the second problem in PR #19
searching for ".type is" in all the codebase found 52 intances when `ev.type is ...` was used to compare the pygame event type.

Fixed by changing `ev.type is ...` to `ev.type == ...`
